### PR TITLE
古いバージョンでエラーを起きなくする

### DIFF
--- a/lib/ruboty/handlers/twitter_stream_checker.rb
+++ b/lib/ruboty/handlers/twitter_stream_checker.rb
@@ -55,7 +55,7 @@ module Ruboty
       def check_start
         registered.values.each do |value|
           job = Ruboty::TwitterStreamChecker::Job.new(value)
-          job.start(robot)
+          running_jobs[job.id] = job.start(robot)
         end
       end
 

--- a/lib/ruboty/handlers/twitter_stream_checker.rb
+++ b/lib/ruboty/handlers/twitter_stream_checker.rb
@@ -22,6 +22,7 @@ module Ruboty
 
       def initialize(*args)
         super
+        compatible_brain
         check_start
       end
 
@@ -118,6 +119,14 @@ module Ruboty
 
       def job_id_for_message(message)
         Digest::MD5.hexdigest(message[:check_word])
+      end
+
+      private
+
+      def compatible_brain
+        if registered.is_a(String)
+          robot.brain.data[NAMESPACE] = {}
+        end
       end
     end
   end

--- a/lib/ruboty/handlers/twitter_stream_checker.rb
+++ b/lib/ruboty/handlers/twitter_stream_checker.rb
@@ -22,7 +22,7 @@ module Ruboty
 
       def initialize(*args)
         super
-        compatible_brain
+        cleaning_brain if registered.is_a?(String)
         check_start
       end
 
@@ -123,10 +123,8 @@ module Ruboty
 
       private
 
-      def compatible_brain
-        if registered.is_a(String)
-          robot.brain.data[NAMESPACE] = {}
-        end
+      def cleaning_brain
+        robot.brain.data[NAMESPACE] = {}
       end
     end
   end


### PR DESCRIPTION
古いバージョンから使っているとbrainのフォーマットが異なるのでエラーになる。
古いバージョンのbrainだった場合は一度空にすることでエラーにならないようにする。
